### PR TITLE
Dockerize homesat

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,41 @@
 [![LGTM Grade](https://img.shields.io/lgtm/grade/python/github/nasa/cFS)](https://lgtm.com/projects/g/nasa/cFS/alerts/?mode=list)
 [![LGTM Grade](https://img.shields.io/lgtm/grade/cpp/github/nasa/cFS)](https://lgtm.com/projects/g/nasa/cFS/alerts/?mode=list)
 
+# HomeSat - Built on NASA CFS
+
+The goal of HomeSat is to apply flight software architecture to an in-home,
+headless, and autonomous telemetry collection device. This means that the 
+chosen device (a Raspberry Pi 3) acts as a sort of "satellite", that should 
+perform the following basic functions:
+
+- collect and store telemetry
+- transmit telemetry at regular intervals to a ground station
+- respond to ground station commands
+
+Just like with othe aerospace projects, i.e. [CanSat](http://www.cansatcompetition.com)
+and [Phoenix](https://phxcubesat.asu.edu), HomeSat should use a rigidly defined
+Command and Data Handling (CDH) subsystem for communication, and separate 
+applications for each hardware module. The publish-subscribe model, as defined
+by CFS, will be used for data transfer between applications.
+
+## HomeSat Applications
+
+HomeSat's functionality will be defined entirely by its apps. A single main 
+application will be responsible for coordinating the satellite's high-level
+operations, and smaller applications will constitute the major subsystems. 
+
+Initially, HomeSat will start off as a single application, with submodule 
+functionality broken out into smaller files within the application. 
+
+The planned set of apps will be as follows:
+- Main (CDH)
+- Radio
+- Telemetry (gathering and reporting)
+- Scheduler
+- Shell
+
+---
+
 # Core Flight System - BUNDLE
 
 The Core Flight System (cFS) is a generic flight software architecture framework used on flagship spacecraft, human spacecraft, cubesats, and Raspberry Pi.  This repository is a bundle of submodules that make up the cFS framework.  Note the "lab" apps are intended as examples only, and enable this bundle to build, execute, receive commands, and send telemetry.  This is not a flight distribution, which is typically made up of the cFE, OSAL, PSP, and a selection of flight apps that correspond to specific mission requirements.

--- a/cfs-base-image.dockerfile
+++ b/cfs-base-image.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 RUN apt-get update
 RUN apt-get install -y apt-utils
 RUN apt-get install -y gcc g++ make cmake gcc-multilib g++-multilib

--- a/cfs-base-image.dockerfile
+++ b/cfs-base-image.dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:18.04
+RUN apt-get update
+RUN apt-get install -y apt-utils
+RUN apt-get install -y gcc g++ make cmake gcc-multilib g++-multilib

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services: # build artifacts
+    # The CFS base image is simply a ubuntu 20.04 image containing the required build tools
+    cfs-base-image:
+        image: cfs-base-image
+        build:
+            context: .
+            dockerfile: cfs-base-image.dockerfile
+        
+    
+    # The HomeSat image that actually stores and runs the project itself
+    homesat:
+        build:
+            context: .
+            dockerfile: homesat.dockerfile
+        depends_on: 
+        - cfs-base-image
+        # After CFS 289f8c0 (PSP 12e2607), requires privileged access for i.e. pipe creation and max queue depth errors
+        privileged: true

--- a/homesat.dockerfile
+++ b/homesat.dockerfile
@@ -1,10 +1,10 @@
 FROM cfs-base-image:latest
 
 # Write all project files to the container
-COPY ./ /cfs
+COPY ./ /HomeSat
 
 # Place all work in this directory
-WORKDIR /cfs
+WORKDIR /HomeSat
 
 # Prepare PC-linux build 
 RUN cp cfe/cmake/Makefile.sample Makefile

--- a/homesat.dockerfile
+++ b/homesat.dockerfile
@@ -1,0 +1,16 @@
+FROM cfs-base-image:latest
+
+# Write all project files to the container
+COPY ./ /cfs
+
+# Place all work in this directory
+WORKDIR /cfs
+
+# Prepare PC-linux build 
+RUN cp cfe/cmake/Makefile.sample Makefile
+RUN cp -r cfe/cmake/sample_defs sample_defs
+# RUN sed -i 's/undef OSAL_DEBUG_PERMISSIVE_MODE/define OSAL_DEBUG_PERMISSIVE_MODE/g' sample_defs/default_osconfig.h
+RUN make SIMULATION=native prep 
+RUN make 
+RUN make install
+CMD cd build/exe/cpu1/ && ./core-cpu1

--- a/homesat.dockerfile
+++ b/homesat.dockerfile
@@ -9,7 +9,6 @@ WORKDIR /cfs
 # Prepare PC-linux build 
 RUN cp cfe/cmake/Makefile.sample Makefile
 RUN cp -r cfe/cmake/sample_defs sample_defs
-# RUN sed -i 's/undef OSAL_DEBUG_PERMISSIVE_MODE/define OSAL_DEBUG_PERMISSIVE_MODE/g' sample_defs/default_osconfig.h
 RUN make SIMULATION=native prep 
 RUN make 
 RUN make install


### PR DESCRIPTION
# Dockerize HomeSat

These commits aim to allow HomeSat (CFS) to be run within a Docker container. This will allow safe, isolated testing on a local system prior to deployment on actual hardware.

## Details

Add relevant files to run HomeSat (CFS) within a Ubuntu 20.04 Docker container:
- Add base dockerfile (Ubuntu and dependencies)
- Add HomeSat dockerfile (CFS source code)
- Add docker compose file (build/run)

Steps taken to test the contribution:
1. Install Docker (and Compose)
1. Run the command in the root project folder: `docker-compose up --build`
1. Examine terminal output to see nominal CFS printouts, i.e. `stop flywheel`

A clear and concise description of how this contribution will change behavior and level of impact.
 - No impact to behavior

System(s) tested on
 - Hardware: MacBook Pro 13" (2017)
 - OS: macOS Big Sur  11.0.1
